### PR TITLE
dont lock on output completion

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.lua]
+indent_style = space
+indent_size = 2

--- a/main.lua
+++ b/main.lua
@@ -1,13 +1,14 @@
 local output_history = {first = 1; last = 0}
 local output_history_length = 100
 
-trigger.add("^(.+)$", {}, function(_, line)
-    if output_history.last > output_history_length then
-      output_history[output_history.first] = nil
-      output_history.first = output_history.first + 1
-    end
-    output_history.last = output_history.last + 1
-    output_history[output_history.last] = line:line()
+mud.add_output_listener(function (line)
+  if output_history.last > output_history_length then
+    output_history[output_history.first] = nil
+    output_history.first = output_history.first + 1
+  end
+  output_history.last = output_history.last + 1
+  output_history[output_history.last] = line:line()
+  return line
 end)
 
 local function complete_setting(input)

--- a/main.lua
+++ b/main.lua
@@ -73,10 +73,10 @@ local function complete(input)
     local command = file_command_matches[2]
     completions = complete_filepath(filepath, command)
   elseif set_command_re:test(input) then
-    local set_command_matches = file_command_re:match(input)
     completions = complete_setting(input)
   else
     completions = complete_on_mud_output(input)
+    lock = false
   end
   return completions, lock
 end


### PR DESCRIPTION
When completing from the set of words received from the mud I think it's
useful if the default completions are also included. These will include
previously sent commands.

